### PR TITLE
fix: warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.22.x
-
-      - name: Checkout code
-        uses: actions/checkout@v4
           
       - name: Cache Go Modules
         uses: actions/cache@v4


### PR DESCRIPTION
Tests
Restore cache failed: Dependencies file is not found in /home/runner/work/thetiptop/thetiptop. Supported file pattern: go.sum
